### PR TITLE
Update evt.reply to use 'allow_html' + bump ver

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.poll
 
 # A PEP 440 compliant version string.
-version: 1.0.0
+version: 1.0.1
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.

--- a/poll.py
+++ b/poll.py
@@ -82,7 +82,7 @@ class PollPlugin(Plugin):
             )
             response = f"{question}<br />{choice_list}"
 
-        await evt.reply(response, html_in_markdown=True)
+        await evt.reply(response, allow_html=True)
 
     @poll.subcommand("vote", help="Votes for an option")
     @command.argument(
@@ -106,7 +106,7 @@ class PollPlugin(Plugin):
     @poll.subcommand("results", help="Prints out the current results of the poll")
     async def handler(self, evt: MessageEvent) -> None:
         await evt.mark_read()
-        await evt.reply(self.currentPoll.get_results(), html_in_markdown=True)
+        await evt.reply(self.currentPoll.get_results(), allow_html=True)
 
     @poll.subcommand("close", help="Ends the poll")
     async def handler(self, evt: MessageEvent) -> None:


### PR DESCRIPTION
This PR also fixes an error due to change in API upstream: `reply()` arg `html_in_markdown` was changed to `allow_html` in maubot recently.

https://github.com/maubot/maubot/commit/1d03fd83df88c3b271b9fe0b638384b105796258