### PR TITLE
choose more obvious emoji available on both Element and Slack clients

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.poll
 
 # A PEP 440 compliant version string.
-version: 2.0.1
+version: 2.0.2
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.

--- a/poll.py
+++ b/poll.py
@@ -8,8 +8,8 @@ from maubot.handlers import command
 
 
 QUOTES_REGEX = r"\"?\s*?\""  # Regex to split string between quotes
-# [Thumbs Up, Thumbs Down, Grinning, Ghost, Robot, Okay Hand, Clapping Hands, Hundred]
-REACTIONS = ["\U0001F44D", "\U0001F44E", "\U0001F600", "\U0001F47B", "\U0001F916", "\U0001F44C", "\U0001F44F", "\U0001F4AF"]
+# [Octopus, Ghost, Robot, Okay Hand, Clapping Hands, Hundred, Pizza Slice, Taco, Bomb, Checquered Flag]
+REACTIONS = ["\U0001F44D", "\U0001F44E", "\U0001F419", "\U0001F47B", "\U0001F916", "\U0001F44C", "\U0001F44F", "\U0001F4AF", "\U0001F355", "\U0001F32E", "\U0001F4A3", "\U0001F3C1"]
 
 class Poll:
     def __init__(self, question, choices):


### PR DESCRIPTION
I ran into difficulty choosing the correct "grinning face" emoji across platforms, so I started by replacing that with something else (octopus). I also removed the thumbs_up and thumbs_down variants because they were being counted by the Maubot Karma plugin. then I added a few more options just to add variety, and ensure that they're all really obvious choices regardless of unicode visiblity or naming.

Not a major improvement, but simple enough to make it more friendly.